### PR TITLE
Do not execute paths in node_modules for bower install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "node_modules/bower/bin/bower install"
+    "postinstall": "bower install"
   },
   "ember-addon": {
     "main": "index"


### PR DESCRIPTION
When using the `scripts` section of your `package.json` by default it adds all binaries that are in your deps and devDeps to your path. This means that `bower` is available without having to specify `node_modules/foo/bar/bin/bar`.

Also, if npm can dedupe the requirements it will. This means that the `bower` that we are supposed to use may _not_ be in this projects node_modules folder.
