### PR TITLE
pass --allow-root and --config.interactive=false to bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "bower install --allow-root"
+    "postinstall": "bower install --allow-root --config.interactive=false"
   },
   "ember-addon": {
     "main": "index"


### PR DESCRIPTION
As mentioned in https://github.com/jakecraige/ember-cli-qunit/issues/6 I run into some problems with ember-cli-qunit, since I have to run ember-cli as root in an automation process. 

The two added flags for bower eliminate my problems. I'm not sure if it is a good solution and/or if everybody wants to have these flags enabled...
