### PR TITLE
Update QUnit version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-qunit",
   "dependencies": {
-    "qunit": "~1.12.0",
+    "qunit": "~1.15.0",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
     "ember-qunit-notifications": "~0.0.4",
     "ember-qunit": "~0.1.8"


### PR DESCRIPTION
Would it be possible to bump QUnit to the current version? There are some features that I'm using in my app that only 1.15.0 supports.
