### PR TITLE
Allow ember-cli to remove inline styles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-vendor

--- a/index.js
+++ b/index.js
@@ -25,6 +25,12 @@ module.exports = {
         app.bowerDirectory + '/qunit-notifications/index.js',
       ];
 
+
+      var addonOptions = target.options['ember-cli-qunit'];
+      if (addonOptions && !addonOptions.disableContainerStyles) {
+        fileAssets.push('vendor/ember-cli-qunit/test-container-styles.css');
+      }
+
       var imgAssets = [
         app.bowerDirectory + '/ember-qunit-notifications/passed.png',
         app.bowerDirectory + '/ember-qunit-notifications/failed.png',

--- a/vendor/ember-cli-qunit/test-container-styles.css
+++ b/vendor/ember-cli-qunit/test-container-styles.css
@@ -1,0 +1,14 @@
+#ember-testing-container {
+  position: absolute;
+  background: white;
+  bottom: 0;
+  right: 0;
+  width: 640px;
+  height: 384px;
+  overflow: auto;
+  z-index: 9999;
+  border: 1px solid #ccc;
+}
+#ember-testing {
+  zoom: 50%;
+}


### PR DESCRIPTION
Once this lands, we can remove https://github.com/ember-cli/ember-cli/blob/e78168ba4a293a28474fab795f1c93fc4dde0988/blueprints/app/files/tests/index.html#L16-L31 as the inline styles cause issues with CSP.