### PR TITLE
Improved test runner ui - Moves preview window side-by-side with tests

### DIFF
--- a/templates/test-body.html
+++ b/templates/test-body.html
@@ -1,6 +1,4 @@
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>
-
-<div id="ember-testing-container">
-  <div id="ember-testing"></div>
-</div>
+<iframe id="ember-testing-container" src="about:blank">
+</iframe>

--- a/vendor/ember-cli-qunit/qunit-configuration.js
+++ b/vendor/ember-cli-qunit/qunit-configuration.js
@@ -13,6 +13,14 @@ if (QUnit.notifications) {
 }
 
 jQuery(document).ready(function() {
-  var containerVisibility = QUnit.urlParams.nocontainer ? 'hidden' : 'visible';
-  document.getElementById('ember-testing-container').style.visibility = containerVisibility;
+  if(QUnit.urlParams.nocontainer) {
+    document.getElementById('ember-testing-container').style.visibility = 'hidden';
+    document.getElementById('qunit').style.width = "100%";
+  }
+
+  var appContainer = document.getElementById('ember-testing-container').contentWindow.document;
+  // Copy the head of the main test html file to the iFrame to get stylesheets
+  appContainer.head.innerHTML = document.head.innerHTML;
+
+  appContainer.body.style.zoom = "50%";
 });

--- a/vendor/ember-cli-qunit/test-container-styles.css
+++ b/vendor/ember-cli-qunit/test-container-styles.css
@@ -1,14 +1,23 @@
 #ember-testing-container {
   position: absolute;
-  background: white;
-  bottom: 0;
+  top: 0;
   right: 0;
-  width: 640px;
-  height: 384px;
+  width: 50%;
+  height: 100%;
   overflow: auto;
   z-index: 9999;
   border: 1px solid #ccc;
+  background: white;
 }
-#ember-testing {
-  zoom: 50%;
+
+#qunit {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 50%;
+  height: 100%;
+  overflow: auto;
+  z-index: 9999;
+  border: 1px solid #ccc;
+  background: white;
 }


### PR DESCRIPTION
I've been attempting to improve the test runner in `ember-cli` so that its less annoying. I've had problems with modals blocking out the test runner and with styles from my app affecting QUnit and vice versa. This is my least hacky attempt, by far, and I hope someone can push me in the right direction to make it even better. 

This pr makes the app container an iframe and give's half the screen to the runner and half to the app container.  An example:

![Image of improved runner](https://www.dropbox.com/s/nz3suhf2mxph4m9/Screenshot%202015-01-30%2014.27.36.png?dl=1)

Contrasted with before:
![Image of before improvement](https://www.dropbox.com/s/mbiyfl591pccmwb/Screenshot%202015-01-30%2014.54.43.png?dl=1)

In addition to the code in this pr, in my app, in `startApp`, I had to do this to set my app's `rootElement` to the iframe's body:

``` js
  attributes.rootElement = document.getElementById('ember-testing-container').contentWindow.document.body;
```

Is there a way this can be done from `ember-cli-qunit`? 

To get the styles available in the app container iframe, it's coping the entire `head` of the main test index.html into the iframe as the `head`. To me this is pretty questionable and I hope we can find another solution. 

Limitations: 
- The app css still affects the look of the runner. You may notice in my screenshot that the QUnit options at the top look different than normal, it's because generic elements are styled in a framework my app is using.
