### PR TITLE
Update to ember-qunit 0.2.0.

### DIFF
--- a/blueprints/ember-cli-qunit/index.js
+++ b/blueprints/ember-cli-qunit/index.js
@@ -19,7 +19,7 @@ module.exports = {
         return addonContext.addBowerPackageToProject('ember-qunit-notifications', '0.0.5');
       })
       .then(function() {
-        return addonContext.addBowerPackageToProject('ember-qunit', '0.1.8');
+        return addonContext.addBowerPackageToProject('ember-qunit', 'rwjblue/ember-qunit-builds#0.2.0');
       });
   }
 };

--- a/index.js
+++ b/index.js
@@ -39,7 +39,12 @@ module.exports = {
         app.bowerDirectory + '/ember-qunit-notifications/failed.png',
       ];
 
-      app.import(app.bowerDirectory + '/ember-qunit/dist/named-amd/main.js', {
+      var emberQunitPath = app.bowerDirectory + '/ember-qunit/ember-qunit.amd.js';
+      if (!fs.existsSync(emberQunitPath)) {
+        emberQunitPath = app.bowerDirectory + '/ember-qunit/named-amd/main.js';
+      }
+
+      app.import(emberQunitPath, {
         type: 'test',
         exports: {
           'ember-qunit': [


### PR DESCRIPTION
Updates to allow either ember-qunit 0.1.x or ember-qunit 0.2.x (by checking for the existence of the specific file locations).

Needs to wait until ember-qunit 0.2.0 is shipped (which is blocked on https://github.com/switchfly/ember-test-helpers/pull/12 at the moment).