### PR TITLE
Add a short delay before starting tests.

### DIFF
--- a/vendor/ember-cli-qunit/qunit-configuration.js
+++ b/vendor/ember-cli-qunit/qunit-configuration.js
@@ -1,5 +1,6 @@
 /* globals jQuery,QUnit */
 
+QUnit.config.autostart = false;
 QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container' });
 QUnit.config.urlConfig.push({ id: 'nojshint', label: 'Disable JSHint'});
 

--- a/vendor/ember-cli-qunit/test-loader.js
+++ b/vendor/ember-cli-qunit/test-loader.js
@@ -5,5 +5,9 @@ jQuery(document).ready(function() {
   TestLoader.prototype.shouldLoadModule = function(moduleName) {
     return moduleName.match(/[-_]test$/) || (!QUnit.urlParams.nojshint && moduleName.match(/\.jshint$/));
   };
-  TestLoader.load();
+
+  setTimeout(function() {
+    TestLoader.load();
+    QUnit.start();
+  }, 250);
 });


### PR DESCRIPTION
This deals with a Chrome bug where if a breakpoint is hit during the evaluation of the page the sourcemaps will not continue to load.