### PR TITLE
Compatibility for jQuery builds excluding the core/ready module

### DIFF
--- a/vendor/ember-cli-qunit/qunit-configuration.js
+++ b/vendor/ember-cli-qunit/qunit-configuration.js
@@ -1,4 +1,4 @@
-/* globals jQuery,QUnit */
+/* globals QUnit */
 
 QUnit.config.autostart = false;
 QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container' });
@@ -13,7 +13,5 @@ if (QUnit.notifications) {
   });
 }
 
-jQuery(document).ready(function() {
-  var containerVisibility = QUnit.urlParams.nocontainer ? 'hidden' : 'visible';
-  document.getElementById('ember-testing-container').style.visibility = containerVisibility;
-});
+var containerVisibility = QUnit.urlParams.nocontainer ? 'hidden' : 'visible';
+document.getElementById('ember-testing-container').style.visibility = containerVisibility;

--- a/vendor/ember-cli-qunit/test-loader.js
+++ b/vendor/ember-cli-qunit/test-loader.js
@@ -1,6 +1,6 @@
 /* globals jQuery,QUnit */
 
-jQuery(document).ready(function() {
+jQuery(window).on('load', function() {
   var TestLoader = require('ember-cli/test-loader')['default'];
   TestLoader.prototype.shouldLoadModule = function(moduleName) {
     return moduleName.match(/[-_]test$/) || (!QUnit.urlParams.nojshint && moduleName.match(/\.jshint$/));


### PR DESCRIPTION
Fixes #40 

DOM ready is not needed to config container visibility, since the referenced element is already in the DOM before the script executes.  Using window onload over dom ready for including the test loader, which should be equivalent in this case.