### PR TITLE
Fix target for ember-qunit.

### DIFF
--- a/blueprints/ember-cli-qunit/index.js
+++ b/blueprints/ember-cli-qunit/index.js
@@ -11,7 +11,7 @@ module.exports = {
       { name: 'stefanpenner/ember-cli-shims',    target: '0.0.3'   },
       { name: 'ember-cli/ember-cli-test-loader', target: '0.1.0'   },
       { name: 'ember-qunit-notifications',       target: '0.0.5'   },
-      { name: 'ember-qunit',                     target: 'rwjblue/ember-qunit-builds#0.2.1' }
+      { name: 'ember-qunit',                     target: '0.2.5' }
     ]);
   }
 };


### PR DESCRIPTION
I finally got the bower registry updated so that `ember-qunit` points to the builds registry now.