### PR TITLE
Remove ember-cli-shims requirement.

### DIFF
--- a/blueprints/ember-cli-qunit/index.js
+++ b/blueprints/ember-cli-qunit/index.js
@@ -8,10 +8,9 @@ module.exports = {
   afterInstall: function() {
     return this.addBowerPackagesToProject([
       { name: 'qunit',                           target: '~1.17.0' },
-      { name: 'stefanpenner/ember-cli-shims',    target: '0.0.3'   },
       { name: 'ember-cli/ember-cli-test-loader', target: '0.1.0'   },
       { name: 'ember-qunit-notifications',       target: '0.0.5'   },
-      { name: 'ember-qunit',                     target: '0.2.5' }
+      { name: 'ember-qunit',                     target: '0.2.6' }
     ]);
   }
 };

--- a/index.js
+++ b/index.js
@@ -47,6 +47,12 @@ module.exports = {
       app.import(emberQunitPath, {
         type: 'test',
         exports: {
+          'qunit': [
+            'default',
+            'module',
+            'test'
+          ],
+
           'ember-qunit': [
             'globalize',
             'moduleFor',
@@ -55,13 +61,6 @@ module.exports = {
             'test',
             'setResolver'
           ]
-        }
-      });
-
-      app.import(app.bowerDirectory + '/ember-cli-shims/test-shims.js', {
-        type: 'test',
-        exports: {
-          'qunit': ['default']
         }
       });
 


### PR DESCRIPTION
The `qunit` shim is now provided by `ember-qunit` itself (instead of ember-cli-shims).