### PR TITLE
Prevents module load errors from stopping test run.

### DIFF
--- a/blueprints/ember-cli-qunit/index.js
+++ b/blueprints/ember-cli-qunit/index.js
@@ -8,7 +8,7 @@ module.exports = {
   afterInstall: function() {
     return this.addBowerPackagesToProject([
       { name: 'qunit',                           target: '~1.17.0' },
-      { name: 'ember-cli/ember-cli-test-loader', target: '0.1.0'   },
+      { name: 'ember-cli/ember-cli-test-loader', target: '0.1.1'   },
       { name: 'ember-qunit-notifications',       target: '0.0.5'   },
       { name: 'ember-qunit',                     target: '0.2.6' }
     ]);


### PR DESCRIPTION
Changes from https://github.com/ember-cli/ember-cli-test-loader/pull/7.