### PR TITLE
Ensure modules that fail to load fail the build.

### DIFF
--- a/blueprints/ember-cli-qunit/index.js
+++ b/blueprints/ember-cli-qunit/index.js
@@ -8,7 +8,7 @@ module.exports = {
   afterInstall: function() {
     return this.addBowerPackagesToProject([
       { name: 'qunit',                           target: '~1.17.1' },
-      { name: 'ember-cli/ember-cli-test-loader', target: '0.1.1'   },
+      { name: 'ember-cli/ember-cli-test-loader', target: '0.1.3'   },
       { name: 'ember-qunit-notifications',       target: '0.0.7'   },
       { name: 'ember-qunit',                     target: '0.2.8' }
     ]);

--- a/vendor/ember-cli-qunit/test-loader.js
+++ b/vendor/ember-cli-qunit/test-loader.js
@@ -6,6 +6,13 @@ jQuery(document).ready(function() {
     return moduleName.match(/[-_]test$/) || (!QUnit.urlParams.nojshint && moduleName.match(/\.jshint$/));
   };
 
+  TestLoader.prototype.moduleLoadFailure = function(moduleName, error) {
+    QUnit.module('TestLoader Failures');
+    QUnit.test(moduleName + ': could not be loaded', function() {
+      throw error;
+    });
+  };
+
   setTimeout(function() {
     TestLoader.load();
     QUnit.start();


### PR DESCRIPTION
Previously, if a given test failed to load we would `console.error` the failure, which may or may not help folks find them.  

This PR makes those module load failures actual fail a test, so that you get decent warning/info that a whole module of your tests cannot be run.

![screenshot](http://monosnap.com/image/WJ5CyNsBszjrWSie9Y9TtOj07x8LS3.png)