### PR TITLE
Upgrade ember-qunit to 0.3.0

### DIFF
--- a/blueprints/ember-cli-qunit/index.js
+++ b/blueprints/ember-cli-qunit/index.js
@@ -10,7 +10,7 @@ module.exports = {
       { name: 'qunit',                           target: '~1.17.1' },
       { name: 'ember-cli/ember-cli-test-loader', target: '0.1.3'   },
       { name: 'ember-qunit-notifications',       target: '0.0.7'   },
-      { name: 'ember-qunit',                     target: '0.2.8' }
+      { name: 'ember-qunit',                     target: '0.3.0' }
     ]);
   }
 };


### PR DESCRIPTION
Fixes #54 

`ember-qunit@0.3.0` contains fix for https://github.com/emberjs/data/issues/2924, which resolves issue of container being shared across tests via `this.subject()`