### PR TITLE
Respect user autostart settings.

### DIFF
--- a/vendor/ember-cli-qunit/qunit-configuration.js
+++ b/vendor/ember-cli-qunit/qunit-configuration.js
@@ -1,6 +1,5 @@
 /* globals jQuery,QUnit */
 
-QUnit.config.autostart = false;
 QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container'});
 QUnit.config.urlConfig.push({ id: 'nojshint', label: 'Disable JSHint'});
 QUnit.config.urlConfig.push({ id: 'doccontainer', label: 'Doc test pane'});

--- a/vendor/ember-cli-qunit/test-loader.js
+++ b/vendor/ember-cli-qunit/test-loader.js
@@ -13,8 +13,14 @@ jQuery(document).ready(function() {
     });
   };
 
+  var autostart = QUnit.config.autostart !== false;
+  QUnit.config.autostart = false;
+
   setTimeout(function() {
     TestLoader.load();
-    QUnit.start();
+
+    if (autostart) {
+      QUnit.start();
+    }
   }, 250);
 });


### PR DESCRIPTION
Read `QUnit.config.autostart` after `test-helper` and friends have had a chance
to set the value.  Load the tests in either case, but only start them
automatically if `QUnit.config.autostart` has not been set to false.

This is particularly useful for users who want to debug tests in PhantomJS.