### PR TITLE
Adding a default timeout for QUnit tests.

### DIFF
--- a/vendor/ember-cli-qunit/qunit-configuration.js
+++ b/vendor/ember-cli-qunit/qunit-configuration.js
@@ -3,6 +3,7 @@
 QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container'});
 QUnit.config.urlConfig.push({ id: 'nojshint', label: 'Disable JSHint'});
 QUnit.config.urlConfig.push({ id: 'doccontainer', label: 'Doc test pane'});
+QUnit.config.testTimeout = 300000 //Default Test Timeout 5 Minutes
 
 if (QUnit.notifications) {
   QUnit.notifications({

--- a/vendor/ember-cli-qunit/qunit-configuration.js
+++ b/vendor/ember-cli-qunit/qunit-configuration.js
@@ -3,7 +3,7 @@
 QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container'});
 QUnit.config.urlConfig.push({ id: 'nojshint', label: 'Disable JSHint'});
 QUnit.config.urlConfig.push({ id: 'doccontainer', label: 'Doc test pane'});
-QUnit.config.testTimeout = 300000 //Default Test Timeout 5 Minutes
+QUnit.config.testTimeout = 60000 //Default Test Timeout 60 Seconds
 
 if (QUnit.notifications) {
   QUnit.notifications({


### PR DESCRIPTION
So, we had a developer check in a test that hung our build all weekend.
I would like to propose putting in a default test timeout into this package.

I think that 5 minutes is a really long time for qunit tests, but I'm not sure what kind of long running tests people might have.

I'm open to suggestions regarding the duration of the default timeout.