### PR TITLE
Correct "Doc test pane" to "Dock test pane"

### DIFF
--- a/vendor/ember-cli-qunit/qunit-configuration.js
+++ b/vendor/ember-cli-qunit/qunit-configuration.js
@@ -2,7 +2,7 @@
 
 QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container'});
 QUnit.config.urlConfig.push({ id: 'nojshint', label: 'Disable JSHint'});
-QUnit.config.urlConfig.push({ id: 'doccontainer', label: 'Dock test pane'});
+QUnit.config.urlConfig.push({ id: 'dockcontainer', label: 'Dock container'});
 QUnit.config.testTimeout = 60000; //Default Test Timeout 60 Seconds
 
 if (QUnit.notifications) {
@@ -16,7 +16,7 @@ if (QUnit.notifications) {
 
 jQuery(document).ready(function() {
   var containerVisibility = QUnit.urlParams.nocontainer ? 'hidden' : 'visible';
-  var containerPosition = QUnit.urlParams.doccontainer ? 'absolute' : 'relative';
+  var containerPosition = QUnit.urlParams.dockcontainer ? 'absolute' : 'relative';
   document.getElementById('ember-testing-container').style.visibility = containerVisibility;
   document.getElementById('ember-testing-container').style.position = containerPosition;
 });

--- a/vendor/ember-cli-qunit/qunit-configuration.js
+++ b/vendor/ember-cli-qunit/qunit-configuration.js
@@ -2,7 +2,7 @@
 
 QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container'});
 QUnit.config.urlConfig.push({ id: 'nojshint', label: 'Disable JSHint'});
-QUnit.config.urlConfig.push({ id: 'doccontainer', label: 'Doc test pane'});
+QUnit.config.urlConfig.push({ id: 'doccontainer', label: 'Dock test pane'});
 QUnit.config.testTimeout = 60000; //Default Test Timeout 60 Seconds
 
 if (QUnit.notifications) {


### PR DESCRIPTION
This PR so far only changes the string displayed in the UI. The rest of the code still refers to this option as `doccontainer`. Should all these instances also be changed to `dockcontainer`?

As an aside, it seems to be called a container in one option ("Hide container") but as a test pane in another ("Doc test pane"). Should these be made consistent?