### PR TITLE
Adding qunit-once to ember-cli-qunit

### DIFF
--- a/blueprints/ember-cli-qunit/index.js
+++ b/blueprints/ember-cli-qunit/index.js
@@ -10,7 +10,8 @@ module.exports = {
       { name: 'qunit',                           target: '~1.17.1' },
       { name: 'ember-cli/ember-cli-test-loader', target: '0.1.3'   },
       { name: 'ember-qunit-notifications',       target: '0.0.7'   },
-      { name: 'ember-qunit',                     target: '0.4.1'   }
+      { name: 'ember-qunit',                     target: '0.4.1'   },
+      { name: 'qunit-once',                      target: '0.1.1'   }
     ]);
   }
 };

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ module.exports = {
     if (app.tests) {
       var fileAssets = [
         app.bowerDirectory + '/qunit/qunit/qunit.js',
+        app.bowerDirectory + '/qunit-once/qunit-once.js',
         app.bowerDirectory + '/qunit/qunit/qunit.css'
       ];
 


### PR DESCRIPTION
This adds [qunit-once](https://github.com/bahmutov/qunit-once) to ember-cli to get more lifecycle hooks.  setupOnce and teardownOnce would allow better control of resources for acceptance tests.
