### PR TITLE
Remove 'ember-cli/' path from ember-cli-test-loader in blueprint

### DIFF
--- a/blueprints/ember-cli-qunit/index.js
+++ b/blueprints/ember-cli-qunit/index.js
@@ -8,7 +8,7 @@ module.exports = {
   afterInstall: function() {
     return this.addBowerPackagesToProject([
       { name: 'qunit',                           target: '~1.18.0' },
-      { name: 'ember-cli/ember-cli-test-loader', target: '0.1.3'   },
+      { name: 'ember-cli-test-loader',           target: '0.1.3'   },
       { name: 'ember-qunit-notifications',       target: '0.0.7'   },
       { name: 'ember-qunit',                     target: '0.4.9'   }
     ]);


### PR DESCRIPTION
Fixes issue with using the generator with ember-cli 1.13.5 and up.

```
$ ember -v
version: 1.13.6
node: 2.4.0
npm: 2.13.2
os: linux x64
$ ember new jamocha-shake
...
$ cd jamocha-shake
$ ember generate ember-cli-qunit
version: 1.13.6
installing ember-cli-qunit
Installing browser packages via Bower...
cached git://github.com/dockyard/ember-qunit-notifications.git#0.0.7
cached git://github.com/jquery/qunit.git#1.17.1
cached git://github.com/rwjblue/ember-qunit-builds.git#0.4.6

Package ember-cli/ember-cli-test-loader=ember-cli/ember-cli-test-loader not found
Error: Package ember-cli/ember-cli-test-loader=ember-cli/ember-cli-test-loader not found
```

This might be related to strictness introduced by https://github.com/ember-cli/ember-cli/pull/4430