### PR TITLE
Upgrading broccoli-jshint to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/ember-cli/ember-cli-qunit",
   "dependencies": {
-    "broccoli-jshint": "0.5.6"
+    "broccoli-jshint": "0.5.7"
   },
   "bundledDependencies": []
 }


### PR DESCRIPTION
Latest broccoli-jshint uses latest version of broccoli-filter, which as performance improvements.