### PR TITLE
Allow #ember-testing-container to be optional.

### DIFF
--- a/vendor/ember-cli-qunit/qunit-configuration.js
+++ b/vendor/ember-cli-qunit/qunit-configuration.js
@@ -15,8 +15,11 @@ if (QUnit.notifications) {
 }
 
 jQuery(document).ready(function() {
+  var testContainer = document.getElementById('ember-testing-container');
+  if (!testContainer) { return; }
+
   var containerVisibility = QUnit.urlParams.nocontainer ? 'hidden' : 'visible';
   var containerPosition = QUnit.urlParams.dockcontainer ? 'absolute' : 'relative';
-  document.getElementById('ember-testing-container').style.visibility = containerVisibility;
-  document.getElementById('ember-testing-container').style.position = containerPosition;
+  testContainer.style.visibility = containerVisibility;
+  testContainer.style.position = containerPosition;
 });


### PR DESCRIPTION
QUnit runs tests just fine without any modifications to the DOM. This change is important for running tests that require the application being set on the `<body>` element (scrolling-related in particular) or have CSS that is impacted by the modified application structure.