### PR TITLE
Use ember-qunit as an NPM dependency.

### DIFF
--- a/blueprints/ember-cli-qunit/index.js
+++ b/blueprints/ember-cli-qunit/index.js
@@ -9,8 +9,7 @@ module.exports = {
     return this.addBowerPackagesToProject([
       { name: 'qunit',                           target: '~1.20.0' },
       { name: 'ember-cli-test-loader',           target: '0.2.1'   },
-      { name: 'ember-qunit-notifications',       target: '0.1.0'   },
-      { name: 'ember-qunit',                     target: '0.4.17'   }
+      { name: 'ember-qunit-notifications',       target: '0.1.0'   }
     ]);
   }
 };

--- a/index.js
+++ b/index.js
@@ -2,7 +2,10 @@
 
 var path = require('path');
 var fs   = require('fs');
+var resolve = require('resolve');
 var jshintTrees = require('broccoli-jshint');
+var MergeTrees = require('broccoli-merge-trees');
+
 
 module.exports = {
   name: 'Ember CLI QUnit',
@@ -32,6 +35,20 @@ module.exports = {
 
   blueprintsPath: function() {
     return path.join(__dirname, 'blueprints');
+  },
+
+  treeForAddonTestSupport: function() {
+    var emberQUnitPath = path.dirname(resolve.sync('ember-qunit'));
+    var emberTestHelpersPath = path.dirname(resolve.sync('ember-test-helpers', { basedir: emberQUnitPath }));
+    var klassyPath = path.dirname(resolve.sync('klassy', { basedir: emberTestHelpersPath }));
+
+    var tree = new MergeTrees([
+      this.treeGenerator(emberQUnitPath),
+      this.treeGenerator(emberTestHelpersPath),
+      this.treeGenerator(klassyPath)
+    ]);
+
+    return tree;
   },
 
   included: function included(app, parentAddon) {
@@ -71,31 +88,6 @@ module.exports = {
       if (addonOptions && addonOptions.disableContainerStyles === false) {
         fileAssets.push('vendor/ember-cli-qunit/test-container-styles.css');
       }
-
-      var emberQunitPath = app.bowerDirectory + '/ember-qunit/ember-qunit.amd.js';
-      if (!fs.existsSync(emberQunitPath)) {
-        emberQunitPath = app.bowerDirectory + '/ember-qunit/named-amd/main.js';
-      }
-
-      app.import(emberQunitPath, {
-        type: 'test',
-        exports: {
-          'qunit': [
-            'default',
-            'module',
-            'test'
-          ],
-
-          'ember-qunit': [
-            'globalize',
-            'moduleFor',
-            'moduleForComponent',
-            'moduleForModel',
-            'test',
-            'setResolver'
-          ]
-        }
-      });
 
       fileAssets.forEach(function(file){
         app.import(file, {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
   },
   "homepage": "https://github.com/ember-cli/ember-cli-qunit",
   "dependencies": {
-    "broccoli-jshint": "^1.0.0"
+    "broccoli-jshint": "^1.0.0",
+    "broccoli-merge-trees": "^1.1.0",
+    "ember-qunit": "^0.4.18",
+    "resolve": "^1.1.6"
   },
   "bundledDependencies": []
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,11 @@
   },
   "homepage": "https://github.com/ember-cli/ember-cli-qunit",
   "dependencies": {
+    "broccoli-babel-transpiler": "^5.5.0",
     "broccoli-jshint": "^1.0.0",
     "broccoli-merge-trees": "^1.1.0",
+    "broccoli-sourcemap-concat": "^1.1.6",
+    "ember-cli-version-checker": "^1.1.4",
     "ember-qunit": "^0.4.18",
     "resolve": "^1.1.6"
   },


### PR DESCRIPTION
This removes ember-qunit as a bower dependency (in favor of using NPM
directly).

Currently, this adds ember-qunit, ember-test-helpers, and klassy
(required by ember-test-helpers) to `vendor.js`. That is slightly
unfortunate, as ideally these would be added to `test-support.js`
instead, however there is no mechanism other than `app.import` in
ember-cli today (1.13.x timeframe) to handle this.

IMO, we should add a `addon-test-support` tree, that appends to
`test-support.js` by default. This would allow addons to provide test
helpers much simpler than we can today.