### PR TITLE
Filter non-JS files out of the lint tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var MergeTrees = require('broccoli-merge-trees');
 var BabelTranspiler = require('broccoli-babel-transpiler');
 var Concat = require('broccoli-sourcemap-concat');
 var VersionChecker = require('ember-cli-version-checker');
+var Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'Ember CLI QUnit',
@@ -179,7 +180,7 @@ module.exports = {
 
     var ui = this.ui;
 
-    return jshintTrees(tree, {
+    return jshintTrees(new Funnel(tree, { include: ['**/*.js'] }), {
       jshintrcPath: this.jshintrc[type],
       description: 'JSHint ' +  type + '- QUnit',
       console: this.console

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/ember-cli/ember-cli-qunit",
   "dependencies": {
     "broccoli-babel-transpiler": "^5.5.0",
+    "broccoli-funnel": "^1.0.1",
     "broccoli-jshint": "^1.0.0",
     "broccoli-merge-trees": "^1.1.0",
     "broccoli-sourcemap-concat": "^1.1.6",


### PR DESCRIPTION
When an addon tree contains non-JS files, those files will pass through the JSHint tree untouched, which means they ultimately get duplicated in the app tree as well. If the app happens to also use a preprocessor associated with that extension (which is always the case for an addon's dummy app), those files are then processed twice.

This change just filters down the tree handed off to `broccoli-jshint` to only include `.js` files.

Below are example logs using a doctored-up version of `ember-cli-pegjs`. Note that `addon-parser.pegjs` appears in both input trees in the first log.

Before:
```
PEG toTree input (addon)

└── modules/
   └── modules/my-test-addon/
      └── modules/my-test-addon/parsers/
         └── modules/my-test-addon/parsers/addon-parser.pegjs

PEG toTree input (app)

└── dummy/
   ├── dummy/.gitkeep
   └── dummy/app.js
   └── dummy/components/
      └── dummy/components/app-version.js
   └── dummy/controllers/
      ├── dummy/controllers/array.js
      ├── dummy/controllers/object.js
   └── dummy/index.html
   └── dummy/initializers/
      ├── dummy/initializers/app-version.js
      └── dummy/initializers/export-application-global.js
   └── dummy/my-test-addon/
      └── dummy/my-test-addon/tests/
         └── dummy/my-test-addon/tests/modules/
            └── dummy/my-test-addon/tests/modules/my-test-addon/
               └── dummy/my-test-addon/tests/modules/my-test-addon/parsers/
                  ├── dummy/my-test-addon/tests/modules/my-test-addon/parsers/addon-parser.pegjs
   └── dummy/router.js
   └── dummy/templates/
      └── dummy/templates/application.js
```

After:
```
PEG toTree input (addon)

└── modules/
   └── modules/my-test-addon/
      └── modules/my-test-addon/parsers/
         └── modules/my-test-addon/parsers/addon-parser.pegjs

PEG toTree input (app)

└── dummy/
   ├── dummy/.gitkeep
   └── dummy/app.js
   └── dummy/components/
      └── dummy/components/app-version.js
   └── dummy/controllers/
      ├── dummy/controllers/array.js
      ├── dummy/controllers/object.js
   └── dummy/index.html
   └── dummy/initializers/
      ├── dummy/initializers/app-version.js
      └── dummy/initializers/export-application-global.js
   └── dummy/my-test-addon/
      └── dummy/my-test-addon/tests/
   └── dummy/router.js
   └── dummy/templates/
      └── dummy/templates/application.js
```