### PR TITLE
Use `this._super.included.call(this, target)` in `included` function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ module.exports = {
 
   included: function included(app, parentAddon) {
     var target = (parentAddon || app);
-    this._super.included(target);
+    this._super.included.call(this, target);
 
     this.options = target.options;
 


### PR DESCRIPTION
Hey there,

as discussed with @rwjblue at https://github.com/switchfly/ember-cli-mocha/pull/95, use `this._super.included.call(this, target)` instead of `this._super.included(target)` in `included` function.