### PR TITLE
Fix issues with 1.2.0+ and ember-cli@2.2.0-beta.{1,2}.

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,10 @@ module.exports = {
     var checker = new VersionChecker(this);
     var dep = checker.for('ember-cli', 'npm');
 
-    // support for Ember CLI < 2.2.0-beta.1
     this._shouldImportEmberQUnit = !dep.gt('2.2.0-alpha');
+    // fixed in https://github.com/ember-cli/ember-cli/pull/5274
+    // this can be removed when we no longer support 2.2.0-beta.{1,2}
+    this._shouldImportQUnit = !dep.gt('2.2.0-beta.2');
   },
 
   blueprintsPath: function() {
@@ -71,9 +73,12 @@ module.exports = {
     var qunitPath = path.join(path.dirname(resolve.sync('qunitjs')), '..');
 
     var trees = [
-      tree,
-      this.treeGenerator(qunitPath)
+      tree
     ];
+
+    if (!this._shouldImportQUnit) {
+      trees.push(this.treeGenerator(qunitPath));
+    }
 
     if (this._shouldImportEmberQUnit) {
       // support for Ember CLI < 2.2.0-beta.1
@@ -110,10 +115,21 @@ module.exports = {
     testSupportPath = path.dirname(testSupportPath) || 'assets';
 
     if (app.tests) {
-      var fileAssets = [
-        'vendor/qunit/qunit.js',
-        'vendor/qunit/qunit.css'
-      ];
+      var fileAssets;
+
+      if (this._shouldImportQUnit) {
+        // ember-cli < 2.2.0-beta.3 gets this from bower
+        fileAssets = [
+          target.bowerDirectory + '/qunit/qunit/qunit.js',
+          target.bowerDirectory + '/qunit/qunit/qunit.css'
+        ];
+      } else {
+        fileAssets = [
+          'vendor/qunit/qunit.js',
+          'vendor/qunit/qunit.css'
+        ];
+      }
+
 
       var imgAssets = [];
 


### PR DESCRIPTION
ember-cli@2.2.0-beta.{1,2} had a bug that caused all legacy test files to be appended in the wrong order. This meant when 1.2.0 was released of ember-cli-qunit things completely broke (because QUnit was expected before it was included in the file). The underlying issue was fixed upstream and released in ember-cli@2.2.0-beta.3 (in https://github.com/ember-cli/ember-cli/pull/5274).

This PR adds support for pulling qunit from `bower.json` on ember-cli's < 2.2.0-beta.3 and uses NPM on ember-cli's >= 2.2.0-beta.3.