### PR TITLE
Disabling JSHint linting when linting addon exists.

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,13 +187,17 @@ module.exports = {
   },
 
   lintTree: function(type, tree) {
+    var addonContext = this;
+    var disableLinting = this.options['ember-cli-qunit'] && this.options['ember-cli-qunit'].useLintTree === false;
+    var lintingAddonExists = this.projects.addon.find(function(addon) {
+      return addonContext !== addon && addon.lintTree && addon.isDefaultJSLinter;
+    });
+
     // Skip if useLintTree === false.
-    if (this.options['ember-cli-qunit'] && this.options['ember-cli-qunit'].useLintTree === false) {
+    if (disableLinting || lintingAddonExists) {
       // Fakes an empty broccoli tree
       return { inputTree: tree, rebuild: function() { return []; } };
     }
-
-    var ui = this.ui;
 
     return jshintTrees(tree, {
       jshintrcPath: this.jshintrc[type],


### PR DESCRIPTION
This will allow ember-cli-eslint to take priority when present (and not require users to disable ember-cli-qunit's linting manually).