### PR TITLE
Scale container with CSS transform instead of zoom

### DIFF
--- a/vendor/ember-cli-qunit/test-container-styles.css
+++ b/vendor/ember-cli-qunit/test-container-styles.css
@@ -11,5 +11,8 @@
   margin: 0 auto;
 }
 #ember-testing {
-  zoom: 50%;
+  width: 200%;
+  height: 100%;
+  transform: scale(0.5);
+  transform-origin: top left;
 }


### PR DESCRIPTION
The CSS `zoom` property is not standard — and doesn't work in Firefox (https://developer.mozilla.org/en-US/docs/Web/CSS/zoom). This MR scales down the test container with a CSS transform instead, which fixes the scaling on Firefox.

Tested in Chrome 48, Firefox 46 and Safari 9.