### PR TITLE
Do not require upgrading test-loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1-13
+  - EMBER_TRY_SCENARIO=old-test-loader
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
@@ -32,4 +32,4 @@ install:
   - bower install
 
 script:
-  - ember try $EMBER_TRY_SCENARIO test
+  - ember try:one $EMBER_TRY_SCENARIO

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,13 +8,10 @@ module.exports = {
       }
     },
     {
-      name: 'ember-1-13',
+      name: 'old-test-loader',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
+          'ember-cli-test-loader': '0.2.0'
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ember-cli": "^2.4.2",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-resolver": "^2.0.3",
+    "ember-try": "^0.2.2",
     "loader.js": "^4.0.1"
   }
 }

--- a/vendor/ember-cli-qunit/test-loader.js
+++ b/vendor/ember-cli-qunit/test-loader.js
@@ -19,7 +19,9 @@ jQuery(document).ready(function() {
     addModuleExcludeMatcher(excludeModule);
     addModuleIncludeMatcher(includeModule);
   } else {
-    throw new Error("You must upgrade your version of ember-cli-test-loader to 1.0.0 to use this version of ember-cli-qunit")
+    TestLoader.prototype.shouldLoadModule = function shouldLoadModule(moduleName) {
+      return (moduleName.match(/[-_]test$/) || includeModule(moduleName)) && !excludeModule(moduleName);
+    };
   }
 
   TestLoader.prototype.moduleLoadFailure = function(moduleName, error) {


### PR DESCRIPTION
Addressing #110 and #109.

Also, fixed up some stuff so that tests can run after cloning and `npm install && bower install`. It also enables Travis to be turned on.