### PR TITLE
Prepare for test-loader being in NPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
 env:
   - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=old-test-loader
+  - EMBER_TRY_SCENARIO=npm-test-loader
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/blueprints/ember-cli-qunit/index.js
+++ b/blueprints/ember-cli-qunit/index.js
@@ -1,3 +1,5 @@
+var RSVP = require('rsvp');
+
 module.exports = {
   normalizeEntityName: function() {
     // this prevents an error when the entityName is
@@ -6,9 +8,8 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackagesToProject([
-      { name: 'ember-cli-test-loader',           target: '0.2.1'   },
-      { name: 'ember-qunit-notifications',       target: '0.1.0'   }
-    ]);
+    return this.addBowerPackageToProject('ember-qunit-notifications', '0.1.0').then(function() {
+      return this.addPackageToProject('ember-cli-test-loader', '^1.1.0');
+    });
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "ember": "~2.4.1",
     "ember-cli-shims": "0.1.0",
-    "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -4,7 +4,9 @@ module.exports = {
     {
       name: 'default',
       bower: {
-        dependencies: { }
+        dependencies: {
+          'ember-cli-test-loader': '0.2.2'
+        }
       }
     },
     {
@@ -16,10 +18,20 @@ module.exports = {
       }
     },
     {
+      name: 'npm-test-loader',
+      npm: {
+        devDependencies: {
+          'ember-cli': 'ember-cli/ember-cli',
+          'ember-cli-test-loader': '^1.1.0'
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         dependencies: {
-          'ember': 'components/ember#release'
+          'ember': 'components/ember#release',
+          'ember-cli-test-loader': '0.2.2'
         },
         resolutions: {
           'ember': 'release'
@@ -30,7 +42,8 @@ module.exports = {
       name: 'ember-beta',
       bower: {
         dependencies: {
-          'ember': 'components/ember#beta'
+          'ember': 'components/ember#beta',
+          'ember-cli-test-loader': '0.2.2'
         },
         resolutions: {
           'ember': 'beta'
@@ -41,7 +54,8 @@ module.exports = {
       name: 'ember-canary',
       bower: {
         dependencies: {
-          'ember': 'components/ember#canary'
+          'ember': 'components/ember#canary',
+          'ember-cli-test-loader': '0.2.2'
         },
         resolutions: {
           'ember': 'canary'

--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
   "homepage": "https://github.com/ember-cli/ember-cli-qunit",
   "dependencies": {
     "broccoli-babel-transpiler": "^5.5.0",
-    "broccoli-merge-trees": "^1.1.0",
     "broccoli-concat": "^2.2.0",
+    "broccoli-merge-trees": "^1.1.0",
+    "ember-cli-babel": "^5.1.5",
     "ember-cli-version-checker": "^1.1.4",
     "ember-qunit": "^0.4.18",
     "qunitjs": "^1.20.0",
     "resolve": "^1.1.6",
-    "ember-cli-babel": "^5.1.5"
+    "rsvp": "^3.2.1"
   },
   "bundledDependencies": [],
   "devDependencies": {

--- a/tests/unit/test-loader-test.js
+++ b/tests/unit/test-loader-test.js
@@ -1,9 +1,15 @@
-/* globals QUnit */
+/* globals QUnit, require, requirejs */
 import { module, test } from 'qunit';
+
+var testLoaderModulePath = 'ember-cli-test-loader/test-support/index';
+
+if (!requirejs.entries[testLoaderModulePath]) {
+  testLoaderModulePath = 'ember-cli/test-loader';
+}
 
 module('Unit | test loader', {
   beforeEach() {
-    this.TestLoader = window.require('ember-cli/test-loader')['default'];
+    this.TestLoader = require(testLoaderModulePath)['default'];
 
     this.originalRequire = window.require;
     this.requiredModules = [];

--- a/vendor/ember-cli-qunit/test-loader.js
+++ b/vendor/ember-cli-qunit/test-loader.js
@@ -1,7 +1,13 @@
-/* globals jQuery,QUnit */
+/* globals jQuery, QUnit, require, requirejs */
 
 jQuery(document).ready(function() {
-  var TestLoaderModule = require('ember-cli/test-loader');
+  var testLoaderModulePath = 'ember-cli-test-loader/test-support/index';
+
+  if (!requirejs.entries[testLoaderModulePath]) {
+    testLoaderModulePath = 'ember-cli/test-loader';
+  }
+
+  var TestLoaderModule = require(testLoaderModulePath);
   var TestLoader = TestLoaderModule['default'];
   var addModuleExcludeMatcher = TestLoaderModule['addModuleExcludeMatcher'];
   var addModuleIncludeMatcher = TestLoaderModule['addModuleIncludeMatcher'];


### PR DESCRIPTION
In preparation of `ember-cli-test-loader@1.0.0`. Since the lookup path for `TestLoader` changes, this seems difficult to make backwards compatible. Only idea I have would be to wrap the `require` in a `try...catch` and attempt one path and then the other.

Note: this won't work until ember-cli/ember-cli#5709 lands.