### PR TITLE
Remove JSHint lintTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,6 @@ ember install ember-cli-qunit
 ember generate ember-cli-qunit
 ```
 
-### Turning off JSHint linting
-
-If you want to turn off JSHint linting you can do the following configuration in your `ember-cli-build.js` file:
-
-```
-var app = new EmberApp({
-  'babel': {
-    optional: ['es7.decorators']
-  },
-
-  'ember-cli-qunit': {
-    useLintTree: false
-  }
-});
-```
-
 ### References
 
 * [qunit](https://github.com/jquery/qunit)

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 var path = require('path');
 var fs   = require('fs');
 var resolve = require('resolve');
-var jshintTrees = require('broccoli-jshint');
 var MergeTrees = require('broccoli-merge-trees');
 var BabelTranspiler = require('broccoli-babel-transpiler');
 var Concat = require('broccoli-concat');
@@ -30,28 +29,7 @@ module.exports = {
     return this._dependencyTrees;
   },
 
-  buildConsole: function() {
-    var ui = this.ui;
-
-    if (!ui) {
-      this.console = console;
-      return;
-    }
-
-    this.console = {
-      log: function(data) {
-        ui.writeLine(data);
-      },
-
-      error: function(data) {
-        ui.writeLine(data, 'ERROR');
-      }
-    };
-  },
-
   init: function() {
-    this.buildConsole();
-
     var checker = new VersionChecker(this);
     var dep = checker.for('ember-cli', 'npm');
 
@@ -201,40 +179,5 @@ module.exports = {
 
       return output;
     };
-  },
-
-  lintTree: function(type, tree) {
-    var project = this.project;
-
-    var addonContext = this;
-    var disableLinting = this.options['ember-cli-qunit'] && this.options['ember-cli-qunit'].useLintTree === false;
-    var lintingAddonExists = project.addons.filter(function(addon) {
-      return addonContext !== addon && addon.lintTree && addon.isDefaultJSLinter;
-    }).length > 0;
-
-    // Skip if useLintTree === false.
-    if (disableLinting || lintingAddonExists) {
-      // Fakes an empty broccoli tree
-      return { inputTree: tree, rebuild: function() { return []; } };
-    }
-
-    return jshintTrees(tree, {
-      jshintrcPath: this.jshintrc[type],
-      description: 'JSHint ' +  type + '- QUnit',
-      console: this.console,
-      testGenerator: function(relativePath, passed, errors) {
-        if (errors) {
-          errors = "\\n" + this.escapeErrorString(errors);
-        } else {
-          errors = "";
-        }
-
-        return project.generateTestFile('JSHint - ' + relativePath, [{
-          name: 'should pass jshint',
-          passed: !!passed,
-          errorMessage: relativePath + ' should pass jshint.' + errors
-        }]);
-      }
-    });
   }
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/ember-cli/ember-cli-qunit",
   "dependencies": {
     "broccoli-babel-transpiler": "^5.5.0",
-    "broccoli-jshint": "^1.0.0",
     "broccoli-merge-trees": "^1.1.0",
     "broccoli-concat": "^2.2.0",
     "ember-cli-version-checker": "^1.1.4",


### PR DESCRIPTION
This PR removes the JSHint-based lintTree that has been extracted into the [ember-cli-jshint](https://www.npmjs.com/package/ember-cli-jshint) addon.

This can most-likely be considered a breaking change and should result in a major version bump.

see also https://github.com/ember-cli/ember-cli/pull/5757