### PR TITLE
Make sure to call `_super` from `init`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,8 @@ module.exports = {
   },
 
   init: function() {
+    this._super.apply(this, arguments);
+    
     var checker = new VersionChecker(this);
     var dep = checker.for('ember-cli', 'npm');
 


### PR DESCRIPTION
Without this, `this.project` is undefined because that is set in the supers `init`...