### PR TITLE
Re-throw TestLoader failures during QUnit.done

### DIFF
--- a/vendor/ember-cli-qunit/test-loader.js
+++ b/vendor/ember-cli-qunit/test-loader.js
@@ -30,12 +30,22 @@ jQuery(document).ready(function() {
     };
   }
 
+  var moduleLoadFailures = [];
+
   TestLoader.prototype.moduleLoadFailure = function(moduleName, error) {
+    moduleLoadFailures.push(error);
+
     QUnit.module('TestLoader Failures');
     QUnit.test(moduleName + ': could not be loaded', function() {
       throw error;
     });
   };
+
+  QUnit.done(function() {
+    if (moduleLoadFailures.length) {
+      throw new Error('\n' + moduleLoadFailures.join('\n'));
+    }
+  });
 
   var autostart = QUnit.config.autostart !== false;
   QUnit.config.autostart = false;


### PR DESCRIPTION
Addressing issue #100 with the second approach mentioned in that issue.

Loading failures show up with a filter now:
![screen shot 2016-05-08 at 5 15 34 pm](https://cloud.githubusercontent.com/assets/3526753/15101285/00b0c2f8-1541-11e6-9940-4167514100d3.png)

Existing behavior is retained with an added global failure of all the test modules that didn't load:
![screen shot 2016-05-08 at 5 16 18 pm](https://cloud.githubusercontent.com/assets/3526753/15101286/0512772e-1541-11e6-9f7e-b5d9c525da19.png)
