### PR TITLE
Introduce development mode option

### DIFF
--- a/vendor/ember-cli-qunit/qunit-configuration.js
+++ b/vendor/ember-cli-qunit/qunit-configuration.js
@@ -3,7 +3,9 @@
 QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container'});
 QUnit.config.urlConfig.push({ id: 'nolint', label: 'Disable Linting'});
 QUnit.config.urlConfig.push({ id: 'dockcontainer', label: 'Dock container'});
-QUnit.config.testTimeout = 60000; //Default Test Timeout 60 Seconds
+QUnit.config.urlConfig.push({ id: 'devmode', label: 'Development mode' });
+
+QUnit.config.testTimeout = QUnit.urlParams.devmode ? null : 60000; //Default Test Timeout 60 Seconds
 
 if (QUnit.notifications) {
   QUnit.notifications({
@@ -18,8 +20,15 @@ jQuery(document).ready(function() {
   var testContainer = document.getElementById('ember-testing-container');
   if (!testContainer) { return; }
 
-  var containerVisibility = QUnit.urlParams.nocontainer ? 'hidden' : 'visible';
-  var containerPosition = QUnit.urlParams.dockcontainer ? 'absolute' : 'relative';
+  var params = QUnit.urlParams;
+
+  var containerVisibility = params.nocontainer ? 'hidden' : 'visible';
+  var containerPosition = (params.dockcontainer || params.devmode) ? 'absolute' : 'relative';
+
+  if (params.devmode) {
+    testContainer.className = ' full-screen';
+  }
+
   testContainer.style.visibility = containerVisibility;
   testContainer.style.position = containerPosition;
 });

--- a/vendor/ember-cli-qunit/test-container-styles.css
+++ b/vendor/ember-cli-qunit/test-container-styles.css
@@ -10,6 +10,24 @@
   border: 1px solid #ccc;
   margin: 0 auto;
 }
+
+#ember-testing-container.full-screen {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  z-index: 9999;
+  border: none;
+}
+
 #ember-testing {
-  zoom: 50%;
+  width: 200%;
+  height: 100%;
+  transform: scale(0.5);
+  transform-origin: top left;
+}
+
+.full-screen #ember-testing {
+  position: absolute;
+  width: 100%;
+  transform: scale(1);
 }


### PR DESCRIPTION
**Description**

Adds a new config option to enable a "development" mode that includes a full-screen takeover for the container and removes the test timeout limit.

**Motivation**

When building out features that rely on dynamic or not-yet-ready APIs, it is desirable to be able to work directly with static/mock data. In order to encourage TDD (and testing in general), it would be nice to enable a "development mode" so that developers can more easily interact with the application during an Acceptance test that leverages mock data.

This primarily involves two things:

1. Increasing the size of the container such that it looks and feels like the application normally does.
2. Removing test timeouts so that if a developer uses `pauseTest()` it won't err out on them.

A secondary benefit here is that the developer won't have to repeat user interactions when working on a nested part of a user flow (the test will do it for them).