### PR TITLE
Restyle the runner ui

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,7 @@ module.exports = {
       );
 
       var addonOptions = target.options['ember-cli-qunit'];
+
       // Skip if disableContainerStyles === false.
       if (addonOptions && addonOptions.disableContainerStyles === false) {
         fileAssets.push('vendor/ember-cli-qunit/test-container-styles.css');

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ember-cli": "^2.4.2",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-resolver": "^2.0.3",
+    "ember-cli-test-loader": "^1.1.0",
     "ember-try": "^0.2.2",
     "loader.js": "^4.0.1"
   }

--- a/vendor/ember-cli-qunit/qunit-configuration.js
+++ b/vendor/ember-cli-qunit/qunit-configuration.js
@@ -23,12 +23,10 @@ jQuery(document).ready(function() {
   var params = QUnit.urlParams;
 
   var containerVisibility = params.nocontainer ? 'hidden' : 'visible';
-  var containerPosition = (params.dockcontainer || params.devmode) ? 'absolute' : 'relative';
 
   if (params.devmode) {
     testContainer.className = ' full-screen';
   }
 
   testContainer.style.visibility = containerVisibility;
-  testContainer.style.position = containerPosition;
 });

--- a/vendor/ember-cli-qunit/test-container-styles.css
+++ b/vendor/ember-cli-qunit/test-container-styles.css
@@ -1,33 +1,53 @@
-#ember-testing-container {
-  position: relative;
-  background: white;
-  bottom: 0;
+#qunit {
+  position: absolute;
+  top: 0;
   right: 0;
-  width: 640px;
-  height: 384px;
+  height: 100%;
+  overflow: scroll;
+  width: 33%;
+  background-color: white;
+  word-wrap: break-word;
+  margin: 0;
+  padding: 0;
+}
+#qunit-header {
+  border-radius: 0;
+}
+.qunit-filter {
+  display: block;
+  float: none;
+  margin-left: 0;
+  padding: 0.2em;
+}
+#qunit-modulefilter-container {
+  float: none;
+}
+#qunit-modulefilter {
+  width: 100%;
+}
+
+#ember-testing-container {
+  position: absolute;
+  left: 0;
+  top: 0;
+  background: inherit;
+  border: none;
+  height: 100%;
+  width: 66%;
+  z-index: 0;
+  margin: 0;
+  background: white;
   overflow: auto;
   z-index: 9999;
-  border: 1px solid #ccc;
-  margin: 0 auto;
 }
 
 #ember-testing-container.full-screen {
   width: 100%;
   height: 100%;
+  top: 0;
+  left: 0;
   overflow: auto;
   z-index: 9999;
   border: none;
 }
 
-#ember-testing {
-  width: 200%;
-  height: 100%;
-  transform: scale(0.5);
-  transform-origin: top left;
-}
-
-.full-screen #ember-testing {
-  position: absolute;
-  width: 100%;
-  transform: scale(1);
-}


### PR DESCRIPTION
Dock QUnit UI on the right and make the test container larger.

This is similar to the UI in this tweet: https://twitter.com/ryantotweets/status/754434970882445312

Since this overrides a bunch of QUnit styles let me know if it should be done elsewhere.
