### PR TITLE
Upgrade QUnit to 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,15 +32,16 @@
     "broccoli-merge-trees": "^1.1.0",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-version-checker": "^1.1.4",
-    "ember-qunit": "^0.4.18",
+    "ember-qunit": "^1.0.0-beta.1",
     "qunit-notifications": "^0.1.1",
-    "qunitjs": "^1.20.0",
+    "qunitjs": "^2.0.1",
     "resolve": "^1.1.6",
     "rsvp": "^3.2.1"
   },
   "devDependencies": {
     "ember-cli": "^2.4.2",
     "ember-cli-htmlbars": "^1.0.3",
+    "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.2.2",
     "loader.js": "^4.0.1"

--- a/tests/acceptance/adapter-test.js
+++ b/tests/acceptance/adapter-test.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+import { test } from 'qunit';
+
+moduleForAcceptance('Acceptance | Adapter');
+
+test('starting and stoping async behavior works', function(assert) {
+  assert.expect(2);
+
+  visit('/');
+  andThen(() => assert.ok(true));
+  click('.other-page-link');
+  andThen(() => assert.ok(true));
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,6 +6,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('other-page');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,5 @@
 <h2 id="title">Welcome to Ember</h2>
 
+{{#link-to "other-page" class="other-page-link"}}Go to some other page{{/link-to}}
+
 {{outlet}}

--- a/tests/dummy/app/templates/other-page.hbs
+++ b/tests/dummy/app/templates/other-page.hbs
@@ -1,0 +1,1 @@
+<h3>Some other page</h3>

--- a/vendor/ember-cli-qunit/test-loader.js
+++ b/vendor/ember-cli-qunit/test-loader.js
@@ -15,6 +15,9 @@
   }
 
   ready(function() {
+    var QUnitAdapter = require('ember-qunit').QUnitAdapter;
+    Ember.Test.adapter = QUnitAdapter.create();
+
     var testLoaderModulePath = 'ember-cli-test-loader/test-support/index';
 
     if (!requirejs.entries[testLoaderModulePath]) {


### PR DESCRIPTION
Corollary to https://github.com/rwjblue/ember-qunit/pull/234.

Only real change here is to provide a new test adapter for handling async. This might belong in `ember-qunit` as opposed to this addon, but adding it here was way easier.