### PR TITLE
Use jQuery if it is present.

### DIFF
--- a/vendor/ember-cli-qunit/qunit-configuration.js
+++ b/vendor/ember-cli-qunit/qunit-configuration.js
@@ -1,4 +1,4 @@
-/* globals QUnit */
+/* globals jQuery, QUnit */
 
 (function() {
   QUnit.config.urlConfig.push({ id: 'nocontainer', label: 'Hide container'});
@@ -18,6 +18,11 @@
   }
 
   function ready(fn) {
+    if (typeof jQuery === 'function') {
+      jQuery(document).ready(fn);
+      return;
+    }
+
     if (document.readyState != 'loading'){
       fn();
     } else {

--- a/vendor/ember-cli-qunit/test-loader.js
+++ b/vendor/ember-cli-qunit/test-loader.js
@@ -1,7 +1,12 @@
-/* globals QUnit, require, requirejs */
+/* globals jQuery, QUnit, require, requirejs */
 
 (function() {
   function ready(fn) {
+    if (typeof jQuery === 'function') {
+      jQuery(document).ready(fn);
+      return;
+    }
+
     if (document.readyState != 'loading'){
       fn();
     } else {


### PR DESCRIPTION
In #136 we added support for running without jQuery by using standard
DOM API's for DOM loaded instead of using jQuery for it. Unfortunately,
that change broke the ability to use IE8 (without a major version bump)
because IE8 doesn't support the DOMContentLoaded event properly.

This change brings back usage of `jQuery` when present, but falls back
to using `DOMContentLoaded` when `jQuery` is not available.