### PR TITLE
Use 2x for height and width of #ember-testing.

### DIFF
--- a/vendor/ember-cli-qunit/test-container-styles.css
+++ b/vendor/ember-cli-qunit/test-container-styles.css
@@ -21,7 +21,7 @@
 
 #ember-testing {
   width: 200%;
-  height: 100%;
+  height: 200%;
   transform: scale(0.5);
   transform-origin: top left;
 }


### PR DESCRIPTION
Prior to this change, the testing preview would have the proper width but only half the height.  

### Before

![screenshot](https://monosnap.com/file/E8UKIAAMmyAjeLBjlrlNIVG8mcGID2.png)

### After

![screenshot](https://monosnap.com/file/GE0c0EpmoPq7IZfjptbdwG3FcncMHN.png)