### PR TITLE
Prevent calling `QUnit.start` twice with jQuery 3.0.

### DIFF
--- a/vendor/ember-cli-qunit/test-loader.js
+++ b/vendor/ember-cli-qunit/test-loader.js
@@ -13,6 +13,9 @@
       document.addEventListener('DOMContentLoaded', fn);
     }
   }
+  
+  var autostart = QUnit.config.autostart !== false;
+  QUnit.config.autostart = false;
 
   ready(function() {
     var testLoaderModulePath = 'ember-cli-test-loader/test-support/index';
@@ -60,9 +63,6 @@
         throw new Error('\n' + moduleLoadFailures.join('\n'));
       }
     });
-
-    var autostart = QUnit.config.autostart !== false;
-    QUnit.config.autostart = false;
 
     setTimeout(function() {
       TestLoader.load();


### PR DESCRIPTION
Under jQuery 3.0 `$.ready` is always async (even if the document is already loaded). This is generally a great thing, however we were relying on the fact that it was sync (then adding our own async to ensure it was async).

This change prevents QUnit from auto-starting until our callback is completed.

Related to https://github.com/ember-cli/ember-cli/issues/6247.

**NOTE:** This targets the 2.x branch.