### PR TITLE
Autostart & autoload 

### DIFF
--- a/vendor/ember-cli-qunit/test-loader.js
+++ b/vendor/ember-cli-qunit/test-loader.js
@@ -13,9 +13,6 @@
       document.addEventListener('DOMContentLoaded', fn);
     }
   }
-  
-  var autostart = QUnit.config.autostart !== false;
-  QUnit.config.autostart = false;
 
   ready(function() {
     var testLoaderModulePath = 'ember-cli-test-loader/test-support/index';
@@ -63,6 +60,9 @@
         throw new Error('\n' + moduleLoadFailures.join('\n'));
       }
     });
+
+    var autostart = QUnit.config.autostart !== false;
+    QUnit.config.autostart = false;
 
     setTimeout(function() {
       TestLoader.load();

--- a/vendor/ember-cli-qunit/test-loader.js
+++ b/vendor/ember-cli-qunit/test-loader.js
@@ -64,8 +64,12 @@
     var autostart = QUnit.config.autostart !== false;
     QUnit.config.autostart = false;
 
+    var autoload = QUnit.config.autoload !== false;
+
     setTimeout(function() {
-      TestLoader.load();
+      if (autoload) {
+        TestLoader.load();
+      }
 
       if (autostart) {
         QUnit.start();


### PR DESCRIPTION
Currently, version `2.2.3` doesn't respect the `QUnit.config.autostart` flag if you set it in `test-helper.js` because it is getting accessed in the test loader code too early. Additionally, this introduces the ability to stop the modules from being required immediately by adding an `autoload` option (will open a sibling PR against `master` for this).

cc/ @rwjblue 