### PR TITLE
Replace version check with babel options check

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -21,7 +21,6 @@ module.exports = {
       name: 'npm-test-loader',
       npm: {
         devDependencies: {
-          'ember-cli': 'ember-cli/ember-cli',
           'ember-cli-test-loader': '^1.1.0'
         }
       }

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = {
       throw new SilentError('ember-cli-qunit@3.0.0 and higher requires at least ember-cli@2.2.0. Please downgrade to ember-cli-qunit@2 for older ember-cli version support.');
     }
 
-    this._shouldPreprocessAddonTestSupport = dep.gt('2.11.0-beta.1');
+    this._shouldPreprocessAddonTestSupport = !!this.options && !!this.options.babel;
 
     this.setTestGenerator();
   },


### PR DESCRIPTION
Replacing the bad version check with a feature check instead. Tested with a linked version of Ember-CLI and all seems good this time.

cc/ @rwjblue 