### PR TITLE
Adding template-lint-test to test-loader's nolint test

### DIFF
--- a/tests/unit/test-loader-test.js
+++ b/tests/unit/test-loader-test.js
@@ -21,6 +21,7 @@ module('Unit | test loader', {
       'valid-test': true,
       'valid.jshint': true,
       'valid.lint-test': true,
+      'valid.template-lint-test': true,
       'valid-no-dot-lint-test': true,
       'nohyphentest': true,
     };
@@ -44,6 +45,7 @@ test('with nolint unconfigured', function(assert) {
       'valid-test',
       'valid.jshint',
       'valid.lint-test',
+      'valid.template-lint-test',
       'valid-no-dot-lint-test'
     ],
     "loads modules that end in -test.js, .jshint, or .lint-test");

--- a/vendor/ember-cli-qunit/test-loader.js
+++ b/vendor/ember-cli-qunit/test-loader.js
@@ -34,7 +34,7 @@
 
     function excludeModule(moduleName) {
       return QUnit.urlParams.nolint &&
-        moduleName.match(/\.(jshint|lint-test)$/);
+        moduleName.match(/\.(jshint|lint-test|template-lint-test)$/);
     }
 
     function includeModule(moduleName) {


### PR DESCRIPTION
I first reported this issue https://github.com/rwjblue/ember-template-lint/issues/161, but decided the fix belongs in this project.

`template-lint-test` is used by ember-template-lint tests.