### PR TITLE
Override height in full-screen mode

### DIFF
--- a/vendor/ember-cli-qunit/test-container-styles.css
+++ b/vendor/ember-cli-qunit/test-container-styles.css
@@ -29,5 +29,6 @@
 .full-screen #ember-testing {
   position: absolute;
   width: 100%;
+  height: 100%;
   transform: scale(1);
 }


### PR DESCRIPTION
When running the tests in **development mode** the height is not overridden causing the container to have twice the height.