### PR TITLE
Prevent clobbering custom `this.options.babel`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "6"
 
 sudo: false
 

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = {
     var target = (parentAddon || app);
     this._super.included.call(this, target);
 
-    this.options = target.options;
+    this.targetOptions = target.options;
 
     var testSupportPath = target.options.outputPaths.testSupport.js;
     testSupportPath = testSupportPath.testSupport || testSupportPath;
@@ -130,7 +130,7 @@ module.exports = {
 
   contentFor: function(type) {
     // Skip if insertContentForTestBody === false.
-    if (type === 'test-body' && !(this.options['ember-cli-qunit'] && this.options['ember-cli-qunit'].insertContentForTestBody === false)) {
+    if (type === 'test-body' && !(this.targetOptions['ember-cli-qunit'] && this.targetOptions['ember-cli-qunit'].insertContentForTestBody === false)) {
       return this._readTemplate('test-body');
     }
   },


### PR DESCRIPTION
Setting `this.options` inside of `included` to the options from `lib/broccoli/ember-app` means that we will attempt to transpile with the `options.babel` that the host app / addon is using. Which, as of, 2.13+ that will be babel@6 and therefore incompatible options with ember-cli-babel@5 (which this addon uses).