### PR TITLE
Update to Babel 6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.1.2",
   "description": "QUnit testing package for ember-cli applications",
   "main": "index.js",
+  "engines": {
+    "node": ">= 4.0"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -26,10 +26,9 @@
   },
   "homepage": "https://github.com/ember-cli/ember-cli-qunit",
   "dependencies": {
-    "broccoli-babel-transpiler": "^5.5.0",
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.0",
-    "ember-cli-babel": "^5.1.5",
+    "ember-cli-babel": "^6.0.0-beta.7",
     "ember-cli-test-loader": "^1.1.1",
     "ember-cli-version-checker": "^1.1.4",
     "ember-qunit": "^2.0.0-beta.1",


### PR DESCRIPTION
As part of the work for ember-cli@2.13, all "built in" addons are being updated to use ember-cli-babel@6.