### PR TITLE
don't cover open Module drop-down

### DIFF
--- a/vendor/ember-cli-qunit/test-container-styles.css
+++ b/vendor/ember-cli-qunit/test-container-styles.css
@@ -6,7 +6,7 @@
   width: 640px;
   height: 384px;
   overflow: auto;
-  z-index: 9999;
+  z-index: 98;
   border: 1px solid #ccc;
   margin: 0 auto;
 }
@@ -15,7 +15,7 @@
   width: 100%;
   height: 100%;
   overflow: auto;
-  z-index: 9999;
+  z-index: 98;
   border: none;
 }
 


### PR DESCRIPTION
the `#ember-testing-container` has a z-index of 9999, which I'm guessing is random.  However, the Module dropdown in the Qunit header has a z-index of 99, so when passed tests are hidden and all tests pass, the `#ember-testing-container` covers the dropdown without this fix.  See https://monosnap.com/file/ouYQKdxc1mMzMpStK9SCp3iUnN6eLQ.  I changed `.full-screen` just for consistency, though it works properly either way.