### PR TITLE
Update ember-cli-version-checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-test-loader": "^2.0.0",
-    "ember-cli-version-checker": "^1.1.4",
+    "ember-cli-version-checker": "^2.0.0",
     "ember-qunit": "^2.1.3",
     "qunit-notifications": "^0.1.1",
     "qunitjs": "^2.0.1",


### PR DESCRIPTION
The presence of ember-cli-version-checker prior to 2.0.0 anywhere in an app's dependencies makes it impossible to use dependencies that are hoisted above the ember app's root directory. Now that yarn has workspaces support, that's not an unreasonable thing to want to do.