### PR TITLE
docked testContainer should stick to the bottom of the window

### DIFF
--- a/addon-test-support/ember-cli-qunit.js
+++ b/addon-test-support/ember-cli-qunit.js
@@ -61,8 +61,7 @@ export function setupTestContainer() {
   testContainer.style.position = containerPosition;
 
   let qunitContainer = document.getElementById('qunit');
-  let testContainerHeight = window.getComputedStyle(testContainer).height;
-  if (qunitContainer && params.dockcontainer && testContainerHeight) {
+  if (params.dockcontainer) {
     qunitContainer.style.marginBottom = window.getComputedStyle(testContainer).height;
   }
 }

--- a/addon-test-support/ember-cli-qunit.js
+++ b/addon-test-support/ember-cli-qunit.js
@@ -51,7 +51,7 @@ export function setupTestContainer() {
   let params = QUnit.urlParams;
 
   let containerVisibility = params.nocontainer ? 'hidden' : 'visible';
-  let containerPosition = (params.dockcontainer || params.devmode) ? 'absolute' : 'relative';
+  let containerPosition = (params.dockcontainer || params.devmode) ? 'fixed' : 'relative';
 
   if (params.devmode) {
     testContainer.className = ' full-screen';
@@ -59,6 +59,12 @@ export function setupTestContainer() {
 
   testContainer.style.visibility = containerVisibility;
   testContainer.style.position = containerPosition;
+
+  let qunitContainer = document.getElementById('qunit');
+  let testContainerHeight = window.getComputedStyle(testContainer).height;
+  if (qunitContainer && params.dockcontainer && testContainerHeight) {
+    qunitContainer.style.marginBottom = window.getComputedStyle(testContainer).height;
+  }
 }
 
 /**


### PR DESCRIPTION
Hi, there are some little things in the test ui thats bugging me. Don't know if anyone have notices them before.

## Problem: Floating docked container

### fix: When test container is set to be docked, it should stick to the bottom of the window

**Before:**
![image](https://user-images.githubusercontent.com/1415910/29549899-19cfc36e-870b-11e7-874e-2811e73f4e7b.png)
**After:**
![image](https://user-images.githubusercontent.com/1415910/29549940-53d6fe6a-870b-11e7-9189-9c1a788e37b3.png)


## Problem: Blocking test container

### solution: An additional margin at the bottom of the test result container is added such that the test container won't be blocking the test results when scrolled to the bottom

![image](https://user-images.githubusercontent.com/1415910/29549985-9277796a-870b-11e7-9ce1-122eb7fa2745.png)
