### PR TITLE
Ensure contentFor and setTestGenerator are forwarded to ember-qunit.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,24 @@
 'use strict';
+/* eslint-env node */
 
 module.exports = {
   name: 'ember-cli-qunit',
+
+  contentFor(type) {
+    let output = this.eachAddonInvoke('contentFor', [type]);
+    return output.join('\n');
+  },
 
   // intentionally not calling _super here
   // to avoid these trees being namespaced into
   // `ember-cli-qunit/test-support/`
   treeForAddonTestSupport: function(tree) {
     return this.preprocessJs(tree, {
-      registry: this.registry
+      registry: this.registry,
     });
+  },
+
+  setTestGenerator() {
+    this.eachAddonInvoke('setTestGenerator');
   },
 };


### PR DESCRIPTION
There is no default implementation for `contentFor` or `setTestGenerator` in ember-cli's addon model, which means that nested addons do not have the ability to provide these hooks unless the including addon directly implements the hook and defers to the child addon.

This implements `contentFor` and `setTestGenerator` so that we can let `ember-qunit` do all the heavy lifting...