### PR TITLE
Update minimum version of ember-qunit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.8.1",
-    "ember-qunit": "^3.2.0"
+    "ember-qunit": "^3.2.2"
   },
   "devDependencies": {
     "ember-cli": "~2.17.1",


### PR DESCRIPTION
This version brings two main changes:

* Ensures re-exports from ember-test-helpers are still present (with a
  deprecation).
* Ensures that `Ember.testing` is set properly from "normal" non
  `moduleFor*` and/or `setup*Test` style tests.